### PR TITLE
Add scalar, object ref name override and auto id incrementation support

### DIFF
--- a/lib/MtHaml/Runtime.php
+++ b/lib/MtHaml/Runtime.php
@@ -162,23 +162,24 @@ class Runtime
 		if (!$object) {
 		    return;
 		}
-       
+		
 		$id = null;
 		
 		if (is_object($object)) {
-	        if (is_callable(array($object, 'getId'))) {
-	            $id = $object->getId();
-	        } else if (is_callable(array($object, 'id'))) {
-	            $id = $object->id();
-	        }   
-        }
-        
-        $id = self::getObjectRefClassString($object) . '_' . ($id ?: 'new');
-
-        if (false !== $prefix && null !== $prefix) {
-            $id = $prefix . '_' . $id;
-        }
-        return $id;
+		    if (is_callable(array($object, 'getId'))) {
+		        $id = $object->getId();
+		    } else if (is_callable(array($object, 'id'))) {
+		        $id = $object->id();
+		    }   
+		}
+		
+		$id = self::getObjectRefClassString($object) . '_' . ($id ?: 'new');
+		
+		if (false !== $prefix && null !== $prefix) {
+		    $id = $prefix . '_' . $id;
+		}
+		
+		return $id;
     }
     
     static public function getObjectRefClassString($object)

--- a/test/MtHaml/Tests/RuntimeTest.php
+++ b/test/MtHaml/Tests/RuntimeTest.php
@@ -199,7 +199,7 @@ class RuntimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider getGetObjectRefScalarData
+     * @dataProvider getNonObjectRefData
      */
     public function testGetNonObjectRefData($expect, $data)
     {
@@ -210,7 +210,7 @@ class RuntimeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect.'_new', $result);
     }
 
-    public function getGetObjectRefScalarData()
+    public function getNonObjectRefData()
     {
         return array(
         	'array' => array('array', array(1)),
@@ -218,6 +218,7 @@ class RuntimeTest extends \PHPUnit_Framework_TestCase
             'integer' => array('integer', 1),
             'double' => array('double', 1.1),
             'boolean' => array('boolean', true),
+            'resource' => array('resource', tmpfile())
         );
     }
 


### PR DESCRIPTION
Some changes in Object Reference implementation:
1. Scalars are supported, in order to follow original Ruby implementation:

```
$str = 'hello';
$int = 12;
%div[$str] // generates <div class="string" id="string_hello">
%div[$int] // generates <div class="integer" id="integer_12">
```
1. Object ids are auto-incremented if there is no id methods.
   The aim is to prevent html ids collisions. Incrementation is based on class name:

```
$std = new stdClass;
%div[$std] // generates <div class="std_class" id="std_class_1">
%div[$std] // generates <div class="sdt_class" id="std_class_2">
$foo = new Foo();
%div[$std] // generates <div class="foo" id="foo_1">
```
1. Object Reference id can be overwritten with hamlObjectRef() method (see #23):

```
class foo {
  public function hamlObjectRef() {
    return 'customId';
  }
}
```

4; Uses of is_callable() instead of method_exists(), in order to be sure that method is really callable in given context.
