### PR TITLE
fix a wrong typed var name

### DIFF
--- a/lib/MtHaml/Target/TargetAbstract.php
+++ b/lib/MtHaml/Target/TargetAbstract.php
@@ -35,7 +35,7 @@ abstract class TargetAbstract implements TargetInterface
 
     public function setParserFactory($factory)
     {
-        $this->parserFactory = $parserFactory;
+        $this->parserFactory = $factory;
     }
 
     public function createParser(Environment $env, array $options)


### PR DESCRIPTION
argument $factory is typed wrong.

```
    public function setParserFactory($factory)
    {
        $this->parserFactory = $parserFactory;
    }
```
