### PR TITLE
Fix !!! 5 trigger error when format = html5

### DIFF
--- a/lib/MtHaml/Node/Doctype.php
+++ b/lib/MtHaml/Node/Doctype.php
@@ -30,6 +30,7 @@ class Doctype extends NodeAbstract
         ),
         'html5' => array(
             '' => '<!DOCTYPE html>',
+            '5' => '<!DOCTYPE html>',
         ),
     );
 

--- a/test/MtHaml/Tests/Node/DoctypeTest.php
+++ b/test/MtHaml/Tests/Node/DoctypeTest.php
@@ -44,7 +44,7 @@ class DoctypeTest extends \PHPUnit_Framework_TestCase
     public function getGetDoctypeTriggersWarningWhenInvalidData()
     {
         return array(
-            array('html5', "No such doctype '!!! invalid' for the format 'html5'. Available doctypes for the current format are: '!!!'"),
+            array('html5', "No such doctype '!!! invalid' for the format 'html5'. Available doctypes for the current format are: '!!!', '!!! 5'"),
             array('xhtml', "No such doctype '!!! invalid' for the format 'xhtml'. Available doctypes for the current format are: '!!!', '!!! strict', '!!! frameset', '!!! 5', '!!! 1.1', '!!! basic', '!!! mobile', '!!! rdfa'"),
         );
     }

--- a/test/MtHaml/Tests/fixtures/environment/doctype.test
+++ b/test/MtHaml/Tests/fixtures/environment/doctype.test
@@ -5,10 +5,12 @@ echo $env->compileString($parts['HAML'], "$file.haml");
 
 --HAML--
 !!!
+!!! 5
 !!! XML
 !!! XML utf-8
 !!! XML iso-8859-15
 --EXPECT--
+<!DOCTYPE html>
 <!DOCTYPE html>
 
 

--- a/test/MtHaml/Tests/fixtures/environment/doctype_invalid.test
+++ b/test/MtHaml/Tests/fixtures/environment/doctype_invalid.test
@@ -9,4 +9,4 @@ echo $env->compileString($parts['HAML'], "$file.haml");
 
 --EXCEPTION--
 PHPUnit_Framework_Error_Warning
-No such doctype '!!! invalid' for the format 'html5'. Available doctypes for the current format are: '!!!'
+No such doctype '!!! invalid' for the format 'html5'. Available doctypes for the current format are: '!!!', '!!! 5'

--- a/test/MtHaml/Tests/fixtures/environment/doctype_php.test
+++ b/test/MtHaml/Tests/fixtures/environment/doctype_php.test
@@ -5,10 +5,12 @@ echo $env->compileString($parts['HAML'], "$file.haml");
 
 --HAML--
 !!!
+!!! 5
 !!! XML
 !!! XML utf-8
 !!! XML iso-8859-15
 --EXPECT--
+<!DOCTYPE html>
 <!DOCTYPE html>
 
 


### PR DESCRIPTION
According to ruby haml, even the format set to html5 when !!! 5 still
give you <!DOCTYPE html>

https://github.com/haml/haml/blob/09d14bcbef256ed99ef3bc24bd400db339d19175/test/engine_test.rb#L1043
