### PR TITLE
Introduce safe_functions in PHP environments

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -116,6 +116,17 @@ Email <?php echo htmlspecialchars($user->getEmail(), ENT_QUOTES, 'UTF-8'); ?>
 <a href="<?php echo htmlspecialchars($user->getUrl(), ENT_QUOTES, 'UTF-8'); ?>">Home page</a>
 ```
 
+For PHP environments, you can also define _safe functions_ for functions that
+already escape things by default:
+
+``` php
+new MtHaml\Environment('php', array('safe_functions' => array('htmlspecialchars')));
+```
+
+``` haml
+%li =htmlspecialchars("<b>")
+```
+
 ## Twig
 
 Using [Twig][4] in HAML gives more control over what can be executed, what variables and functions are exposed to the templates, etc. This also allows to use all of Twig's awesome features like template inheritance, macros, blocks, filters, functions, tests, ...

--- a/lib/MtHaml/Environment.php
+++ b/lib/MtHaml/Environment.php
@@ -15,6 +15,7 @@ class Environment
     protected $options = array(
         'format' => 'html5',
         'enable_escaper' => true,
+        'safe_functions' => array(),
         'escape_html' => true,
         'escape_attrs' => true,
         'cdata' => true,

--- a/lib/MtHaml/NodeVisitor/PhpRenderer.php
+++ b/lib/MtHaml/NodeVisitor/PhpRenderer.php
@@ -61,6 +61,17 @@ class PhpRenderer extends RendererAbstract
         }
     }
 
+    protected function isSafeFunction($content) {
+      $safe_functions = $this->env->getOption('safe_functions');
+
+      foreach ($safe_functions as $s) {
+        if (preg_match("#^" . $s . "\\s*\\(#", trim($content))) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     public function enterInsert(Insert $node)
     {
         $content = $node->getContent();
@@ -70,7 +81,9 @@ class PhpRenderer extends RendererAbstract
             $fmt = '<?php echo %s; ?>';
 
             if ($node->getEscaping()->isEnabled()) {
-                if ($node->getEscaping()->isOnce()) {
+                if ($this->isSafeFunction($content)) {
+                    $fmt = "<?php echo %s; ?>";
+                } else if ($node->getEscaping()->isOnce()) {
                     $fmt = "<?php echo htmlspecialchars(%s,ENT_QUOTES,'%s',false); ?>";
                 } else {
                     $fmt = "<?php echo htmlspecialchars(%s,ENT_QUOTES,'%s'); ?>";

--- a/test/MtHaml/Tests/fixtures/environment/php_safe_escaping.test
+++ b/test/MtHaml/Tests/fixtures/environment/php_safe_escaping.test
@@ -1,0 +1,25 @@
+--FILE--
+<?php
+$env = new MtHaml\Environment('php', array('enable_escaper' => true, 'safe_functions' => array('strtoupper')));
+echo $env->compileString($parts['HAML'], "$file.haml");
+--HAML--
+%html
+  %body
+    %li = strtoupper("<b>")
+    %li = strtolower("<b>")
+    %li
+      :php
+        echo strtoupper("<b>")
+--EXPECT--
+<html>
+  <body>
+    <li><?php echo strtoupper("<b>"); ?></li>
+    <li><?php echo htmlspecialchars(strtolower("<b>"),ENT_QUOTES,'UTF-8'); ?></li>
+    <li>
+      <?php
+        echo strtoupper("<b>")
+      ?>
+    </li>
+  </body>
+</html>
+


### PR DESCRIPTION
Currently with PHP environments, it's really difficult to use helpers that already return escaped HTML, for example:

```haml
%ul
  %li
    :php
      echo link_to("a", "b");
```

This PR adds an environment option `safe_functions` which, for PHP environments, defines a list of functions which will not automatically be `htmlspecialchars`d. By default this list is empty. This makes HAML templates much shorter and much more familiar to Ruby developers:

```php
new MtHaml\Environment('php', array('safe_functions' => array('link_to')));
```

```haml
%ul
  %li =link_to("a", "b")
```