### PR TITLE
Remove redundant indentation inside Run block

### DIFF
--- a/lib/MtHaml/NodeVisitor/PhpRenderer.php
+++ b/lib/MtHaml/NodeVisitor/PhpRenderer.php
@@ -96,12 +96,13 @@ class PhpRenderer extends RendererAbstract
 
         if (!$node->isBlock()) {
             if (preg_match('~[:;]\s*$~', $content)) {
-                $this->write(sprintf('<?php %s ?>' , $content));
+                $this->write(sprintf('<?php %s ?>' , $content), true);
             } else {
-                $this->write(sprintf('<?php %s; ?>' , $content));
+                $this->write(sprintf('<?php %s; ?>' , $content), true);
             }
         } else {
-            $this->write(sprintf('<?php %s { ?>' , $content));
+            $this->write(sprintf('<?php %s { ?>' , $content), true);
+            $this->undent();
         }
     }
 
@@ -111,13 +112,14 @@ class PhpRenderer extends RendererAbstract
 
         $content = $this->trimInlineComments($node->getContent());
 
-        $this->write(sprintf('<?php } %s { ?>' , $content));
+        $this->write(sprintf('<?php } %s { ?>' , $content), true);
     }
 
     public function leaveTopBlock(Run $node)
     {
         if ($node->isBlock()) {
-            $this->write('<?php } ?>');
+            $this->write('<?php } ?>', true);
+            $this->indent();
         }
     }
 

--- a/lib/MtHaml/NodeVisitor/PhpRenderer.php
+++ b/lib/MtHaml/NodeVisitor/PhpRenderer.php
@@ -96,12 +96,12 @@ class PhpRenderer extends RendererAbstract
 
         if (!$node->isBlock()) {
             if (preg_match('~[:;]\s*$~', $content)) {
-                $this->write(sprintf('<?php %s ?>' , $content), true);
+                $this->write(sprintf('<?php %s ?>' , $content), false);
             } else {
-                $this->write(sprintf('<?php %s; ?>' , $content), true);
+                $this->write(sprintf('<?php %s; ?>' , $content), false);
             }
         } else {
-            $this->write(sprintf('<?php %s { ?>' , $content), true);
+            $this->write(sprintf('<?php %s { ?>' , $content), false);
             $this->undent();
         }
     }
@@ -112,13 +112,13 @@ class PhpRenderer extends RendererAbstract
 
         $content = $this->trimInlineComments($node->getContent());
 
-        $this->write(sprintf('<?php } %s { ?>' , $content), true);
+        $this->write(sprintf('<?php } %s { ?>' , $content), false);
     }
 
     public function leaveTopBlock(Run $node)
     {
         if ($node->isBlock()) {
-            $this->write('<?php } ?>', true);
+            $this->write('<?php } ?>', false);
             $this->indent();
         }
     }


### PR DESCRIPTION
Suppose we have the following template:

    %body
      - $options = [ 'One', 'Two', 'Three', 'Four', 'Five' ]

      - if (count($options))
        %ul
          - foreach ($options as $item)
            %li= $item
      - else
        %div No options!

Now it generates well-indented PHP code like this:

    <body>
      <?php $options = [ 'One', 'Two', 'Three', 'Four', 'Five' ]; ?>
      <?php if (count($options)) { ?>
        <ul>
          <?php foreach ($options as $item) { ?>
            <li><?php echo htmlspecialchars($item,ENT_QUOTES,'UTF-8'); ?></li>
          <?php } ?>
        </ul>
      <?php } else { ?>
        <div>No options!</div>
      <?php } ?>
    </body>

But in fact the output HTML code has some redundant indentation:

    <body>
            <ul>
                  <li>One</li>
                  <li>Two</li>
                  <li>Three</li>
                  <li>Four</li>
                  <li>Five</li>
              </ul>
      </body>

It would be nice to have something like this:

    <body>
      <ul>
        <li>One</li>
        <li>Two</li>
        <li>Three</li>
        <li>Four</li>
        <li>Five</li>
      </ul>
    </body>

This HTML code is much more pretty :)

I have fixed this issue, may be this will be useful for someone.
