### PR TITLE
Trimming whitespace from filter name

### DIFF
--- a/lib/MtHaml/Node/Filter.php
+++ b/lib/MtHaml/Node/Filter.php
@@ -17,7 +17,7 @@ class Filter extends NodeAbstract
 
     public function getFilter()
     {
-        return $this->filter;
+        return trim($this->filter);
     }
 
     public function addChild(NodeAbstract $node)


### PR DESCRIPTION
Spaces directly after the filter in haml broke the filter key check