### PR TITLE
Update CommonMark filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "coffeescript/coffeescript": "~1",
         "michelf/php-markdown": "~1.3",
         "erusev/parsedown": "*",
-        "league/commonmark": ">=0.5",
+        "league/commonmark": ">=0.9",
         "cebe/markdown": "~1",
         "kzykhys/ciconia": "~1",
         "fluxbb/commonmark": "~1@dev",

--- a/lib/MtHaml/Filter/Markdown/CommonMark.php
+++ b/lib/MtHaml/Filter/Markdown/CommonMark.php
@@ -2,24 +2,21 @@
 
 namespace MtHaml\Filter\Markdown;
 
-use League\CommonMark\DocParser;
-use League\CommonMark\HtmlRenderer;
+use League\CommonMark\Converter;
 use MtHaml\Filter\Markdown;
 
 class CommonMark extends Markdown
 {
-    private $parser;
-    private $renderer;
+    private $converter;
 
-    public function __construct(DocParser $parser, HtmlRenderer $renderer, $forceOptimization = false)
+    public function __construct(Converter $converter, $forceOptimization = false)
     {
         parent::__construct($forceOptimization);
-        $this->parser = $parser;
-        $this->renderer = $renderer;
+        $this->converter = $converter;
     }
 
     public function filter($content, array $context, $options)
     {
-        return $this->renderer->renderBlock($this->parser->parse($content));
+        return $this->converter->convertToHtml($content);
     }
 }

--- a/test/MtHaml/Tests/fixtures/environment/less_filter_leafo.test
+++ b/test/MtHaml/Tests/fixtures/environment/less_filter_leafo.test
@@ -1,5 +1,7 @@
 --FILE--
 <?php
+// enforce class \lessc from "leafo/lessphp" package and fix conflict with the same class from "oyejorge/less.php" package
+new \lessc_formatter_classic;
 $filter = new MtHaml\Filter\Less\LeafoLess(new \lessc);
 $env = new MtHaml\Environment('twig', array('enable_escaper' => false), array('less' => $filter));
 echo $env->compileString($parts['HAML'], "$file.haml");

--- a/test/MtHaml/Tests/fixtures/environment/markdown_filter_commonmark.test
+++ b/test/MtHaml/Tests/fixtures/environment/markdown_filter_commonmark.test
@@ -1,7 +1,6 @@
 --FILE--
 <?php
-$cmEnv = League\CommonMark\Environment::createCommonMarkEnvironment();
-$filter = new MtHaml\Filter\Markdown\CommonMark(new League\CommonMark\DocParser($cmEnv), new League\CommonMark\HtmlRenderer($cmEnv));
+$filter = new MtHaml\Filter\Markdown\CommonMark(new League\CommonMark\CommonMarkConverter());
 $env = new MtHaml\Environment('twig', array('enable_escaper' => false), array('markdown' => $filter));
 echo $env->compileString($parts['HAML'], "$file.haml");
 


### PR DESCRIPTION
We should be depend on public API instead of internal implementation. In version ``0.10`` was replaced ``HtmlRendererInterface`` with ``ElementRendererInterface``.