### PR TITLE
Update loader.php (depreciated interface)

### DIFF
--- a/lib/MtHaml/Support/Twig/Loader.php
+++ b/lib/MtHaml/Support/Twig/Loader.php
@@ -17,7 +17,7 @@ use MtHaml\Environment;
  * $twig->setLoader($mthaml, new \MtHaml\Support\Twig\Loader($origLoader));
  * </code>
  */
-class Loader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterface
+class Loader implements \Twig_LoaderInterface
 {
     protected $env;
     protected $loader;
@@ -66,7 +66,7 @@ class Loader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterface
      */
     public function exists($name)
     {
-        if ($this->loader instanceof \Twig_ExistsLoaderInterface) {
+        if ($this->loader instanceof \Twig_LoaderInterface) {
             return $this->loader->exists($name);
         } else {
             try {


### PR DESCRIPTION
Twig_ExistsLoaderInterface is no longuer used in Twig and is now depreciated, as explained here :http://twig.sensiolabs.org/doc/deprecated.html

This interface has been merged with Twig_LoaderInterface.

Can you please accept this change request so we can contine using this bundle with futur versions of Twig ?

Thanks !

(great work btw)
