### PR TITLE
[WIP] Fix Fatal Error missing method getSourceContext with TWIG 2

### DIFF
--- a/lib/MtHaml/Support/Twig/Loader.php
+++ b/lib/MtHaml/Support/Twig/Loader.php
@@ -78,4 +78,12 @@ class Loader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterface
             }
         }
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getSourceContext($name)
+    {
+        return $this->loader->getSourceContext($name);
+    }
 }


### PR DESCRIPTION
Twig_LoaderInterface implement this method : `getSourceContext`