### PR TITLE
Update links in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -256,10 +256,10 @@ Add yours: https://github.com/arnaud-lb/MtHaml/edit/master/README.markdown
 
 MtHaml is released under the MIT license (same as HAML/Ruby).
 
-[1]: http://haml-lang.com/
-[2]: http://haml-lang.com/tutorial.html
-[3]: http://haml-lang.com/docs/yardoc/file.HAML_REFERENCE.html
-[4]: http://www.twig-project.org/
-[5]: http://haml-lang.com/docs/yardoc/file.HAML_REFERENCE.html#attribute_methods
-[6]: http://sass-lang.com/
+[1]: https://haml.info
+[2]: https://haml.info/tutorial.html
+[3]: https://haml.info/docs/yardoc/file.REFERENCE.html
+[4]: https://twig.symfony.com
+[5]: https://haml.info/docs/yardoc/file.HAML_REFERENCE.html#attribute_methods
+[6]: https://sass-lang.com
 [7]: https://github.com/arnaud-lb/MtHaml/blob/master/examples/README.md


### PR DESCRIPTION
- update haml url, and there was no redirect from old site (haml-lang.com -> haml.info)
- twig url has moved, but there is a redirect still (twig-project.org -> twig.symfony.com)
- update all links to use https